### PR TITLE
Exposes volume for the database in the docker build

### DIFF
--- a/awair-api/build.gradle
+++ b/awair-api/build.gradle
@@ -18,6 +18,14 @@ task cleanStatic(type: Delete) {
 
 clean.dependsOn 'cleanStatic'
 
+tasks.named("dockerfile") {
+    instruction """ENV MICRONAUT_ENVIRONMENTS=production """
+    instruction """VOLUME /db"""
+}
+
+tasks.named('dockerBuild') {
+    images = ["${rootProject.name}"]
+}
 repositories {
     maven {
         url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
@@ -75,5 +83,4 @@ micronaut {
         optimizeNetty = true
     }
 }
-
 

--- a/awair-api/src/main/resources/application-production.properties
+++ b/awair-api/src/main/resources/application-production.properties
@@ -1,0 +1,2 @@
+# Reads/Creates the database in the /db folder, to make it easier to mount a volume in docker:
+datasources.default.url=jdbc\:h2\:file\:/db/readings-database-prod;LOCK_TIMEOUT\=10000;DB_CLOSE_ON_EXIT\=FALSE

--- a/awair-api/src/main/resources/application.properties
+++ b/awair-api/src/main/resources/application.properties
@@ -6,7 +6,7 @@ micronaut.router.static-resources.default.paths=classpath:META-INF/resources,cla
 micronaut.http.services.awair.url=http://127.0.0.1
 datasources.default.dialect=H2
 datasources.default.driver-class-name=org.h2.Driver
-datasources.default.url=jdbc\:h2\:file\:./readings-database;LOCK_TIMEOUT\=10000;DB_CLOSE_ON_EXIT\=FALSE
+datasources.default.url=jdbc\:h2\:file\:./readings-database-dev;LOCK_TIMEOUT\=10000;DB_CLOSE_ON_EXIT\=FALSE
 datasources.default.username=sa
 datasources.default.password=
 flyway.datasources.default.enabled=true


### PR DESCRIPTION
Uses a root folder in the docker build by default, and exposes the volume to ease the work of upgrading the application in production.